### PR TITLE
Add inline link types

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -72,14 +72,18 @@ The actuator element represents actuators such as the X5-4.  It is assumed to ha
 The link element refers to a parameterized rigid body with two parameters (extension and twist).  All links have one output interface.
 
 **Required attributes:**
-- `type` (string/enum) the only currently supported value is X5
+- `type` (string/enum) Currently supported values:
+  - X5
+  - X5Inline
+  - X5InlineIn
+  - X5InlineOut
 - `extension` (floating point formula, meters)
 - `twist` (floating point formula, radians)
 
 **Example:**
 
 ```xml
-<link type="X5" extension="0.25" twist="pi/2"/>
+<type="X5" extension="0.25" twist="pi/2"/>
 ```
 
 ### `<bracket>`

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -83,7 +83,7 @@ The link element refers to a parameterized rigid body with two parameters (exten
 **Example:**
 
 ```xml
-<type="X5" extension="0.25" twist="pi/2"/>
+<link type="X5" extension="0.25" twist="pi/2"/>
 ```
 
 ### `<bracket>`


### PR DESCRIPTION
Note -- the "X5Inline" has inline adapters at both ends, and the "X5InlineIn" and "X5InlineOut" only have adapters at the respective end; the other end defaults to the standard "90*" type.